### PR TITLE
add cache for robot internal node names

### DIFF
--- a/controllers/referee/referee.py
+++ b/controllers/referee/referee.py
@@ -691,15 +691,20 @@ class Referee:
                 fallen = True
             for i in range(n):
                 point = contact_points[i].point
-                node = self.supervisor.getFromId(contact_points[i].node_id)
-                if not node:
-                    continue
-                name_field = node.getField('name')
-                member = 'unknown body part'
-                if name_field:
-                    name = name_field.getSFString()
-                    if name in player['tagged_solids']:
-                        member = player['tagged_solids'][name]
+                member = player['node_names'].get(contact_points[i].node_id)
+                if member is None:
+                    print("cache miss")
+                    node = self.supervisor.getFromId(contact_points[i].node_id)
+                    if not node:
+                        continue
+                    name_field = node.getField('name')
+                    member = 'unknown body part'
+                    if name_field:
+                        name = name_field.getSFString()
+                        if name in player['tagged_solids']:
+                            member = player['tagged_solids'][name]
+                    player['node_names'][contact_points[i].node_id] = member
+
                 if point[2] > self.field.turf_depth:  # not a contact with the ground
                     if not early_game_interruption and point in self.ball.contact_points:  # ball contact
                         if member in ['arm', 'hand']:

--- a/controllers/referee/team.py
+++ b/controllers/referee/team.py
@@ -71,3 +71,4 @@ class Team(SimpleNamespace):
             player['velocity_buffer'] = [[0] * 6] * window_size
             player['ball_handling_start'] = None
             player['ball_handling_last'] = None
+            player['node_names'] = {} # used for caching node_id -> name pairs of a robot for contact point analysis


### PR DESCRIPTION
getting the name of a proto internal node would require to get it newly every time from webots (not use the field list inside the supervisor.c)
this would mean the field list grows each step and as it is traversed each time to find the field before requesting the field from the simulator.
This caused the time required by the referee to increase with each step 

before:
![image](https://user-images.githubusercontent.com/31923619/213497372-046c5653-4c35-4ec5-bf11-4fffdbfb5f1d.png)

after: 
![image](https://user-images.githubusercontent.com/31923619/213497005-bb6e088c-b8d4-4f2a-be70-ed327e5a998f.png)

